### PR TITLE
Only redraw bitmap for mask element when invalidated

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -14,6 +14,7 @@ public class RNCMaskedView extends ReactViewGroup {
   private static final String TAG = "RNCMaskedView";
 
   private Bitmap mBitmapMask = null;
+  private boolean mBitmapMaskInvalidated = false;
   private Paint mPaint;
   private PorterDuffXfermode mPorterDuffXferMode;
 
@@ -29,8 +30,12 @@ public class RNCMaskedView extends ReactViewGroup {
   protected void dispatchDraw(Canvas canvas) {
     super.dispatchDraw(canvas);
 
-    // redraw mask element to support animated elements
-    updateBitmapMask();
+    if (mBitmapMaskInvalidated) {
+      // redraw mask element to support animated elements
+      updateBitmapMask();
+
+      mBitmapMaskInvalidated = false;
+    }
 
     // draw the mask
     if (mBitmapMask != null) {
@@ -41,11 +46,23 @@ public class RNCMaskedView extends ReactViewGroup {
   }
 
   @Override
+  public void onDescendantInvalidated(View child, View target) {
+    super.onDescendantInvalidated(child, target);
+
+    if (!mBitmapMaskInvalidated) {
+      View maskView = getChildAt(0);
+      if (maskView.equals(child)) {
+        mBitmapMaskInvalidated = true;
+      }
+    }
+  }
+
+  @Override
   protected void onLayout(boolean changed, int l, int t, int r, int b) {
     super.onLayout(changed, l, t, r, b);
 
     if (changed) {
-      updateBitmapMask();
+      mBitmapMaskInvalidated = true;
     }
   }
 


### PR DESCRIPTION
# Overview

I ran into the same problems as others with low FPS on Android, https://github.com/react-native-masked-view/masked-view/issues/88 and https://github.com/react-native-masked-view/masked-view/issues/93. 

Instead of naively redrawing the mask element on each draw this invalidates the stored bitmap when the mask element is invalidated. I believe this fixes unnecessary redraws for mask elements while still supporting animated mask elements. Basically this is an improvement on the previous fix here:  

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan

Use mask element on Android and you should see 60 fps. 
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
