### PR TITLE
Removed note about lack of Expo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ React Native MaskedView for iOS and Android.
 - [x] iOS
 - [x] Android
 
-_Note: React Native MaskedView is not currently supported by Expo unless you "eject"._
-
 ## Getting Started
 
 ```


### PR DESCRIPTION
It seems this library [is supported by Expo's managed workflow](https://docs.expo.io/versions/latest/sdk/masked-view/) so I removed the warning.