### PR TITLE
fix: Fixing bug that made masked view unresponsive after re-attaching

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -66,6 +66,12 @@ public class RNCMaskedView extends ReactViewGroup {
     }
   }
 
+  @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    mBitmapMaskInvalidated = true;
+  }
+
   private void updateBitmapMask() {
     if (this.mBitmapMask != null) {
       this.mBitmapMask.recycle();


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

When including a masked-view in one route (using a library like [react navigation](https://reactnavigation.org/)), and the user navigates to a new route on the stack and presses the back button, the masked-view will not rerender any more.

The problem is that the bitmap invalidation does not happen when the view is attached to the window. Causing calls of React native to `dispatchDraw` to not actually draw, keeping this component in a permanent state of `mBitmapMaskInvalidated = false;`

