### PR TITLE
Performance fix for Android by enabling hardware acceleration

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -20,7 +20,7 @@ public class RNCMaskedView extends ReactViewGroup {
 
   public RNCMaskedView(Context context) {
     super(context);
-    setLayerType(LAYER_TYPE_SOFTWARE, null);
+    setLayerType(LAYER_TYPE_HARDWARE, null);
 
     mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     mPorterDuffXferMode = new PorterDuffXfermode(PorterDuff.Mode.DST_IN);


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
We were having a lot of issues with performance on android such as explained in #110 but also some other users are facing in #88. By enabling hardware acceleration (default is set to software and results in extremely poor performance) for the Android Canvas we managed to solve these issues entirely. The project ran at 60fps, similar to IOS.

Here is a video showing software and hardware in action:
[Hardware Acceleration OFF](https://www.dropbox.com/s/tp92z4mhwgje2t6/software.webm?dl=0) - performance is so bad it's impacting the recording, sorry.
[Hardware Acceleration ON](https://www.dropbox.com/s/7hc0enqmitf0ijh/hardware.webm?dl=0)

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
When lots of re-renders are happening to a screen, the default code has extremely poor performance (as seen in the video). You can test this by creating a simple screen with a few MaskedView views and animating a few elements (which require for constant re-rendering at 60fps). You will notice this will result in bad performance overall only on Android and no issues on IOS.

It's a simple fix but it gets the results we have been looking for in our project.
