### PR TITLE
remove buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
-  buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
# Overview

Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
