### PR TITLE
Allow Android rendering mode (hardware/software) to be controlled via a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ The following image demonstrates that you can put almost anything behind the mas
 | ------- | -------- |
 | element | Yes      |
 
+### `androidRenderingMode`
+
+By default `hardware` rendering mode will be used for best performance, however if you need to animate your `maskElement` then you’ll need to switch to `software` to get your mask to update. This prop only affects Android.
+
+| Type                   | Required | Default    |
+| ---------------------- | -------- | ---------- |
+| `software`, `hardware` | No       | `hardware` |
+
 <!-- badges -->
 
 [build-badge]: https://github.com/react-native-masked-view/masked-view/workflows/Build/badge.svg

--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -20,7 +20,9 @@ public class RNCMaskedView extends ReactViewGroup {
 
   public RNCMaskedView(Context context) {
     super(context);
-    setLayerType(LAYER_TYPE_HARDWARE, null);
+
+    // Default to hardware rendering, androidRenderingMode prop will override
+    setRenderingMode("hardware");
 
     mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     mPorterDuffXferMode = new PorterDuffXfermode(PorterDuff.Mode.DST_IN);
@@ -104,5 +106,13 @@ public class RNCMaskedView extends ReactViewGroup {
     view.draw(canvas);
 
     return bitmap;
+  }
+
+  public void setRenderingMode(String renderingMode) {
+    if (renderingMode.equals("software")) {
+      setLayerType(LAYER_TYPE_SOFTWARE, null);
+    } else {
+      setLayerType(LAYER_TYPE_HARDWARE, null);
+    }
   }
 }

--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
@@ -2,6 +2,7 @@ package org.reactnative.maskedview;
 
 import android.view.View;
 import android.widget.Toast;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -26,5 +27,12 @@ public class RNCMaskedViewManager extends ViewGroupManager<RNCMaskedView> {
   @Override
   protected RNCMaskedView createViewInstance(ThemedReactContext themedReactContext) {
     return new RNCMaskedView(themedReactContext);
+  }
+
+  @ReactProp(name = "androidRenderingMode")
+  public void setAndroidRenderingMode(RNCMaskedView view, @Nullable String renderingMode) {
+    if (renderingMode != null) {
+      view.setRenderingMode(renderingMode);
+    }
   }
 }

--- a/js/MaskedViewTypes.js
+++ b/js/MaskedViewTypes.js
@@ -10,4 +10,8 @@ export type MaskedViewProps = typeof ViewPropTypes &
      * mask for the child element.
      */
     maskElement: Element<any>,
+    /**
+     * Opt into software rendering to enable animated masks.
+     */
+    androidRenderingMode?: 'software' | 'hardware',
   |}>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ import * as ReactNative from 'react-native';
 
 interface MaskedViewProps extends ReactNative.ViewProps {
   maskElement: React.ReactElement;
+  androidRenderingMode?: 'software' | 'hardware';
 }
 /**
  * @see https://github.com/react-native-masked-view/masked-view


### PR DESCRIPTION
#116 improved performance, but disabled the ability to animate the mask on Android. This PR introduces a new property `androidRenderingMode` which allows the user to choose the rendering mode should they require the ability to animate the mask element and are willing to accept the performance trade-off.

Ideally a way to animate the mask while keeping performance good can be found, but until then this seems like a reasonable compromise.

Fixes #117