### PR TITLE
chore(android): replaced jCenter with maven

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -43,8 +43,8 @@ android {
 
 repositories {
   google()
-  jcenter()
   maven { url "https://jitpack.io" }
+  mavenCentral()
   maven {
     // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
     url "$rootDir/../node_modules/react-native/android"


### PR DESCRIPTION
# Overview

jCenter will be offline in February 2022. I've updated the android project to use maven.

# Test Plan

I've tested the library on a personal project and it builds without issues.
