### PR TITLE
add deprecated-react-native-prop-types

### DIFF
--- a/js/MaskedViewTypes.js
+++ b/js/MaskedViewTypes.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Node, type Element } from 'react';
-import { ViewPropTypes } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 export type MaskedViewProps = typeof ViewPropTypes &
   $ReadOnly<{|


### PR DESCRIPTION
Adding missing dependency deprecated-react-native-prop-types

