### PR TITLE
Use deprecate-react-native-prop-types

### DIFF
--- a/js/MaskedViewTypes.js
+++ b/js/MaskedViewTypes.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Node, type Element } from 'react';
-import { ViewPropTypes } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 export type MaskedViewProps = typeof ViewPropTypes &
   $ReadOnly<{|


### PR DESCRIPTION
Platforms affected
All

What does this PR do?
RN 0.68 has deprecated and will eventually remove ViewPropTypes (see post). This adds the deprecated-react-native-prop-types package and uses that instead.

What testing has been done on this change?
Local testing, to ensure the deprecation warning has been removed.