### PR TITLE
Use deprecate-react-native-prop-types  Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "types",
     "RNCMaskedView.podspec"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "deprecated-react-native-prop-types": "^2.3.0",
+  },
   "devDependencies": {
     "@react-native-community/eslint-config": "^2.0.0",
     "@types/react-native": "^0.63.50",


### PR DESCRIPTION
Platforms affected
All

What does this PR do?
RN 0.68 has deprecated and will eventually remove ViewPropTypes (see post). This adds the deprecated-react-native-prop-types package and uses that instead.

What testing has been done on this change?
Local testing, to ensure the deprecation warning has been removed.