### PR TITLE
Remove deprecated ViewPropTypes

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,7 +17,6 @@ node_modules/warning/.*
 
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
-.*/node_modules/react-native
 
 [include]
 

--- a/js/MaskedViewTypes.js
+++ b/js/MaskedViewTypes.js
@@ -1,8 +1,8 @@
 // @flow
 import { type Node, type Element } from 'react';
-import { ViewPropTypes } from 'react-native';
+import { type ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 
-export type MaskedViewProps = typeof ViewPropTypes &
+export type MaskedViewProps = $Shape<ViewProps> &
   $ReadOnly<{|
     children: Node,
     /**


### PR DESCRIPTION
# Overview

Fixes #168 

Remove deprecated ViewPropTypes and replaced it with Flow Type provided by react-native
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan
flow passes

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
