### PR TITLE
fix: Mask flicker while navigating on Android

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -77,17 +77,14 @@ public class RNCMaskedView extends ReactViewGroup {
   }
 
   private void updateBitmapMask() {
-    if (this.mBitmapMask != null) {
-      this.mBitmapMask.recycle();
-    }
-
     View maskView = getChildAt(0);
     if (maskView != null) {
       maskView.setVisibility(View.VISIBLE);
+      if (this.mBitmapMask != null) {
+        this.mBitmapMask.recycle();
+      }
       this.mBitmapMask = getBitmapFromView(maskView);
       maskView.setVisibility(View.INVISIBLE);
-    } else{
-      this.mBitmapMask = null;
     }
   }
 


### PR DESCRIPTION
# Overview

This PR fixes an issue many users have been experiencing on Android when navigating back from one screen to the other.

Closes https://github.com/react-native-masked-view/masked-view/issues/160 

# Test Plan

1. On Android navigate to a screen with a component that users MaskedView
2. Navigate back using the hardware button 
3. Observe the Mask no longer being removed before the screen is fully hidden 

After 

https://user-images.githubusercontent.com/11707729/191022838-5814bc6d-5c9d-4d5c-a168-d9a4ecf05367.mov



Before

https://user-images.githubusercontent.com/11707729/191020488-acc1b917-6ea4-4238-96f7-47f177a52f40.mov


 