### PR TITLE
build(yarn): set latest classic version

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "types",
     "RNCMaskedView.podspec"
   ],
-  "dependencies": {},
   "devDependencies": {
     "@react-native-community/eslint-config": "^2.0.0",
     "@types/react-native": "^0.63.50",
@@ -51,5 +50,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
# Overview

The project doesn't specify in the `package.json` the package manager used by it, nor its version (you can suppose Yarn; hence the `yarn.lock` file).

Run the `yarn set version classic` command to solve the issue.

# Test Plan

None of the `test:*` scripts should fail.
