### PR TITLE
fix(types): utility type removed from RN 0.71

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,8 @@
 import * as React from 'react';
 import * as ReactNative from 'react-native';
 
+type Constructor<T> = new (...args: any[]) => T;
+
 interface MaskedViewProps extends ReactNative.ViewProps {
   maskElement: React.ReactElement;
   androidRenderingMode?: 'software' | 'hardware';
@@ -11,7 +13,7 @@ interface MaskedViewProps extends ReactNative.ViewProps {
  * @see https://github.com/react-native-masked-view/masked-view
  */
 declare class MaskedViewComponent extends React.Component<MaskedViewProps> {}
-declare const MaskedViewBase: ReactNative.Constructor<
+declare const MaskedViewBase: Constructor<
   ReactNative.NativeMethods
 > &
   typeof MaskedViewComponent;


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Updating to react native 0.71, TypeScript errors on this library. The utility type `Constructor` is private in latest typings. Using this export degrades to `any` type.

`JSX element class does not support attributes because it does not have a 'props' property.`

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

`npx tsc` runs clean after making this change on a RN 0.71 app.