### PR TITLE
fix: deprecated set-output in GitHub Action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
@@ -35,7 +35,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
@@ -56,7 +56,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}


### PR DESCRIPTION
Due to deprecation of `save-state` and `set-output` commands in GitHub Action workflows, this PR should prevent workflows to fail after the 31st May 2023.

Link to GitHub blogg:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/