### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
-
+  namespace = "org.reactnative.maskedview"
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)
     targetSdkVersion safeExtGet('targetSdkVersion', 28)

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.reactnative.maskedview">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
# Summary
Starting from React Native v0.73 , all libraries will need to be updated with these two one-liners due to Android Gradle Plugin upgrade
[discussions-671](https://github.com/react-native-community/discussions-and-proposals/issues/671)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |