### PR TITLE
feat(all): add support  RN <0.71 when add namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,9 +17,34 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+def shouldUseNameSpace = agpVersion >= 7
+def PACKAGE_PROP = "package=\"org.reactnative.maskedview\""
+def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
+def manifestContent = manifestOutFile.getText()
+if(shouldUseNameSpace){
+      manifestContent = manifestContent.replaceAll(
+        PACKAGE_PROP,
+        ''
+    )  
+} else {
+    if(!manifestContent.contains("$PACKAGE_PROP")){
+        manifestContent = manifestContent.replace(
+            '<manifest',
+            "<manifest $PACKAGE_PROP "
+        )
+    }
+}
+manifestContent.replaceAll("  ", " ")
+manifestOutFile.write(manifestContent)
+
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
-  namespace = "org.reactnative.maskedview"
+  
+  if(shouldUseNameSpace){
+    namespace = "org.reactnative.maskedview"
+  }
+
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)
     targetSdkVersion safeExtGet('targetSdkVersion', 28)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
-
+  namespace = "org.reactnative.maskedview"
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)
     targetSdkVersion safeExtGet('targetSdkVersion', 28)

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="org.reactnative.maskedview" xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.reactnative.maskedview">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
# Overview
In [prev-PR](https://github.com/react-native-masked-view/masked-view/pull/195), i remove package from AndroidManifest.xml file, it drop support for RN <0.71. 
Now, I check ANDROID_GRADLE_PLUGIN_VERSION to use namespace and remove package in AndroidManifest.xml file
# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
