### PR TITLE
Calling invalidate in RNCMaskedView

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -59,6 +59,8 @@ public class RNCMaskedView extends ReactViewGroup {
         }
       }
     }
+
+    invalidate();
   }
 
   @Override


### PR DESCRIPTION
# Overview
This pull request adds an `invalidate()` call to `RNCMaskedView.onDescendantInvalidated`

This addresses the following issue: sometimes, the MaskedView would display a stale content even though React re-render happened in one of the children

# Details

As far as I understand, the issue was happening because in `RNCMaskedView.dispatchDraw` we would render the content of the masked view into an off-screen buffer ([link](https://developer.android.com/topic/performance/hardware-accel#layers)) *before* the children would have been re-drawn ([link](https://developer.android.com/reference/android/view/View#dispatchDraw(android.graphics.Canvas))), and later the offscreen buffer would be used by the hardware rendering even though it contains a stale snapshot of the children.

A simple solution is to invalidate the masked view whenever a child is invalidated. This causes an additional `draw()` call to be scheduled for the parent view, and it gets handled at the point where the children have been already updated. 

**Pros:** It's simple and it works. 🙂
**Cons:** It triggers an additional draw where we basically re-render all children into the off-screen buffer. Though it seems that it was being redrawn even more often before https://github.com/react-native-masked-view/masked-view/pull/98, so I guess it's acceptable. 🤷‍♂️

# Test Plan
**Video:** https://youtu.be/4XI00oGdgQ0
**Before the change:** Sometimes, the MaskedView would display a stale content even though React re-render happened in one of the children
**After the change:** Now the MaskedView displays the updated children correctly 


