### PR TITLE
Initial Web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides a React component that renders a masked view.
 
 - [x] iOS
 - [x] Android
-- [ ] Web
+- [x] Web
 
 ## Getting Started
 
@@ -93,6 +93,13 @@ export default App
 The following image demonstrates that you can put almost anything behind the mask. The three examples shown are masked `<View>`, `<Text>`, and `<Image>`.
 
 <div align="center"><img src="img/example.png" width="200"></img></div>
+
+### Web Usage
+
+you need to install moden-screenshot package for web usage:
+```sh
+yarn add modern-screenshot
+```
 
 ### Props
 

--- a/js/MaskedView.web.js
+++ b/js/MaskedView.web.js
@@ -1,8 +1,53 @@
-import React from 'react';
-import { View } from 'react-native';
+import React, { ReactNode, useEffect, useRef, useState } from "react";
+import { View } from "react-native";
+import { domToPng } from "modern-screenshot";
+const MaskedView = ({
+  children,
+  maskElement,
+  style,
+  ...rest
+}) => {
+  const maskRef = useRef(null);
+  const [mask, setMask] = useState("");
+  const snapShot = () => {
+    if (!maskRef.current) return;
+    domToPng(maskRef.current).then((dataUrl) => {
+      setMask(dataUrl);
+    });
+  };
+  useEffect(() => {
+    const observer = new ResizeObserver(snapShot);
+    observer.observe(maskRef.current!);
+    return () => {
+      observer.disconnect();
+    };
+  }, [maskElement]);
 
-function MaskedView({ maskElement, ...props }) {
-  return React.createElement(View, props, maskElement);
-}
+  return (
+    <>
+      <View
+        style={{
+          position: "absolute",
+          transform: [{ translateX: "-100%" }, { translateY: "-100%" }],
+        }}
+      >
+        <div ref={maskRef}>{maskElement}</div>
+      </View>
+
+      <View
+        style={[
+          style,
+          {
+            //@ts-ignore
+            mask: `url(${mask}) center no-repeat`,
+          },
+        ]}
+        {...rest}
+      >
+        {children}
+      </View>
+    </>
+  );
+};
 
 export default MaskedView;


### PR DESCRIPTION
This approach uses `moden-screenshot` package for snapshoting the mask element.
then we put the image as a mask by new CSS mask api.

![Screenshot 2024-05-20 121121](https://github.com/react-native-masked-view/masked-view/assets/36116677/4d33d3bf-4484-4631-b33c-bdd0aff6cebc)

**Note**: I did not check if this method aligns with native versions.